### PR TITLE
Update README to not cause error for gulp.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ var gulp = require('gulp'),
     nightwatch = require('gulp-nightwatch');
 
 gulp.task('default', function() {
-   gulp.src()
+   gulp.src('')
      .pipe(nightwatch({
        configFile: "test/nightwatch.json"
      }));


### PR DESCRIPTION
A simple update to the README to demonstrate proper usage with gulp. Previously in the README, it demonstrated the usage of `gulp.src()` which will cause errors with gulp. Correctly, you need to pass in a string parameter, which in our case can be an empty string - `gulp.src('')`.