### PR TITLE
Bug fix: output location

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,8 +41,7 @@ var nightwatchPlugin = function(options) {
         path.join(__dirname, 'lib', 'background.js'),
         JSON.stringify({
           config: options.configFile,
-          env: 'default',
-          output: 'output'
+          env: 'default'
         })
       ],
       {
@@ -55,6 +54,7 @@ var nightwatchPlugin = function(options) {
     });
 
   }
+
   function queueFile(file) {
     gutil.log("log file");
     if (file) {


### PR DESCRIPTION
`gulp-nightwatch` always specify an `output` location as nightwatch's output location.