### PR TITLE
Return the results of the `.src()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ var gulp = require('gulp'),
     nightwatch = require('gulp-nightwatch');
 
 gulp.task('default', function() {
-  gulp.src('')
+  return gulp.src('')
     .pipe(nightwatch({
       configFile: 'test/nightwatch.json'
     }));
@@ -26,7 +26,7 @@ You can pass command line options to Nightwatch as an array by using the option 
 
 ```javascript
 gulp.task('nightwatch:chrome', function(){
-  gulp.src('')
+  return gulp.src('')
     .pipe(nightwatch({
       configFile: 'test/nightwatch.json',
       cliArgs: [ '--env chrome', '--tag sandbox' ]
@@ -38,7 +38,7 @@ You may use an object instead, if you prefer.
 
 ```javascript
 gulp.task('nightwatch:chrome', function(){
-  gulp.src('')
+  return gulp.src('')
     .pipe(nightwatch({
       configFile: 'test/nightwatch.json',
       cliArgs: {


### PR DESCRIPTION
Gulp tasks do their dependency graph blocking on the return value from `gulp.src()` or whatever.  If those tasks aren't returned, things depending on them will proceed immediately.  This can be a problem for report gathering steps, and for steps which should not proceed until the tests are known to pass (such as auto-publishing.)

Because tasks are often copy and pasted blindly from `readme`s, it seems like these tasks should be ready for that sort of thing.