### PR TITLE
fix exit code check #41

### DIFF
--- a/lib/background.js
+++ b/lib/background.js
@@ -14,7 +14,8 @@ nightwatch.cli(function(argv) {
     argv.test = path.resolve(argv.test);
   }
 
-  nightwatch.runner(argv, function(success, exitCode) {
-      process.exit(exitCode);
+  nightwatch.runner(argv, function(success, code) {
+    let exitCode = code === 1 ? code : success ? 0 : 1;
+    process.exit(exitCode);
   });
 });

--- a/lib/background.js
+++ b/lib/background.js
@@ -14,8 +14,5 @@ nightwatch.cli(function(argv) {
     argv.test = path.resolve(argv.test);
   }
 
-  nightwatch.runner(argv, function(success, code) {
-    let exitCode = code === 1 ? code : success ? 0 : 1;
-    process.exit(exitCode);
-  });
+  nightwatch.runner(argv);
 });

--- a/lib/background.js
+++ b/lib/background.js
@@ -14,8 +14,7 @@ nightwatch.cli(function(argv) {
     argv.test = path.resolve(argv.test);
   }
 
-  nightwatch.runner(argv, function(success, exitCode) {    
+  nightwatch.runner(argv, function(success, exitCode) {
       process.exit(exitCode);
-    }
   });
 });

--- a/lib/background.js
+++ b/lib/background.js
@@ -14,9 +14,9 @@ nightwatch.cli(function(argv) {
     argv.test = path.resolve(argv.test);
   }
 
-  nightwatch.runner(argv, function(success) {
-    if (!success) {
-      process.exit(1);
+  nightwatch.runner(argv, function(success, exitCode) {
+    if (exitCode !== 0) {
+      process.exit(exitCode);
     } else {
       process.exit(0);
     }

--- a/lib/background.js
+++ b/lib/background.js
@@ -14,11 +14,8 @@ nightwatch.cli(function(argv) {
     argv.test = path.resolve(argv.test);
   }
 
-  nightwatch.runner(argv, function(success, exitCode) {
-    if (exitCode !== 0) {
+  nightwatch.runner(argv, function(success, exitCode) {    
       process.exit(exitCode);
-    } else {
-      process.exit(0);
     }
   });
 });


### PR DESCRIPTION
A correct handler for the **exit code** from Nightwatch.
Now the **exit code** on `process.exit()` will be defined by the Nightwatch process itself.

I tested it and I'm able to handle the error on testing my application now.
Tell me what you think about. I hope it helps.