### PR TITLE
Remove dependency on gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 'use strict';
 
 var es = require('event-stream');
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var helper = require('./lib/helper');
 var path = require('path');
 var spawn = require('child_process').spawn;
-var PluginError = gutil.PluginError;
+var PluginError = require('plugin-error');
 
 var PLUGIN_NAME = 'gulp-nightwatch';
 
@@ -44,7 +44,7 @@ var nightwatchPlugin = function(options) {
   }
 
   function startNightwatch() {
-    gutil.log('Starting nightwatch...');
+    log('Starting nightwatch...');
 
     child = spawn(
       'node',
@@ -64,7 +64,7 @@ var nightwatchPlugin = function(options) {
   }
 
   function queueFile(file) {
-    gutil.log("log file");
+    log("log file");
     if (file) {
       files.push(file.path);
     }

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -2,7 +2,7 @@
 
 var parse = require('shell-quote').parse;
 var parseArgs = require('minimist');
-var PluginError = require('gulp-util').PluginError;
+var PluginError = require('plugin-error');
 var util = require('util');
 
 var PLUGIN_NAME = 'gulp-nightwatch';

--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
   "homepage": "https://github.com/tatsuyafw/gulp-nightwatch",
   "dependencies": {
     "event-stream": "^3.1.7",
-    "gulp-util": "^3.0.1",
+    "fancy-log": "^1.3.2",
     "minimist": "^1.1.1",
     "nightwatch": "^0.9.5",
+    "plugin-error": "^1.0.1",
     "shell-quote": "^1.4.3"
   },
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 var nightwatchPlugin = require('../');
 var expect = require('chai').expect;
-var PluginError = require('gulp-util').PluginError;
+var PluginError = require('plugin-error');
 require('mocha');
 
 describe('gulp-nightwatch', function() {


### PR DESCRIPTION
`gulp-util` is deprecated, see also https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5.
This PR removes the dependency.