### PR TITLE
Remove the unnecessary log

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,6 @@ var nightwatchPlugin = function(options) {
   }
 
   function queueFile(file) {
-    log("log file");
     if (file) {
       files.push(file.path);
     }


### PR DESCRIPTION
When starting `gulp-nightwatch`, the meaningless log was displayed as follows.

```
[22:36:24] log file
```

This PR removes that.